### PR TITLE
kswitch: fix bootstrap error

### DIFF
--- a/pkgs/kswitch/default.nix
+++ b/pkgs/kswitch/default.nix
@@ -13,7 +13,7 @@
 
 stdenv.mkDerivation rec {
   pname = "kswitch";
-  version = "1.5.3";
+  version = "1.5.4";
 
   buildInputs = [ makeWrapper ];
   passAsFile = [ "buildCommand" ];

--- a/pkgs/kswitch/kswitch.sh
+++ b/pkgs/kswitch/kswitch.sh
@@ -105,7 +105,7 @@ setup() {
     mkdir -p "$CONFIG_DIR"
   fi
 
-  hasTunnel=$(kubectl config view -o=json | jq '.clusters | map(select(.name == "tunnel")) | length')
+  hasTunnel=$(kubectl config view -o=json | jq 'if .clusters then .clusters else {} end | map(select(.name == "tunnel")) | length')
   if [ ! "$hasTunnel" == "1" ]; then
     log "I'm going to add a cluster named tunnel to the local kube configuration:"
     run_c "kubectl config set-cluster tunnel --server https://localhost:${localPort} --insecure-skip-tls-verify=true"


### PR DESCRIPTION
This part failed on bootstrap since `kubectl config view -o=json` returns the following output:
```
{
    "kind": "Config",
    "apiVersion": "v1",
    "preferences": {},
    "clusters": null,
    "users": null,
    "contexts": null,
    "current-context": ""
}
```