### PR TITLE
Terraform 0.14 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,11 +40,11 @@ jobs:
         cd test
         toolbox update-shell ${GITHUB_SHA}
         nix-shell --run 'jq --help'
-    - name: make-terraform-shell
+    - name: make-terraform14-shell
       run: |
         . /home/${USER}/.nix-profile/etc/profile.d/nix.sh
         cd test
-        SHELL_COMMIT=${GITHUB_SHA} toolbox make-terraform-shell vault flexibleengine http
+        SHELL_COMMIT=${GITHUB_SHA} toolbox make-terraform14-shell vault flexibleengine http null
         nix-shell --run "terraform version"
   shellcheck:
     runs-on: ubuntu-latest

--- a/default.nix
+++ b/default.nix
@@ -84,7 +84,8 @@ rec {
   inherit (pkgs) kubectl stern vault docker-compose cfssl kompose
                  yq jq gopass kubectx  direnv cue go gnupg curl
                  kustomize pre-commit shellcheck terraform-docs tflint
-                 saml2aws envsubst awscli restic azure-cli;
+                 saml2aws envsubst awscli restic azure-cli
+                 terraform_0_12 terraform_0_13 terraform_0_14;
 
   ansible = pkgs.ansible_2_9;
 
@@ -92,9 +93,7 @@ rec {
 
   helm = pkgs.kubernetes-helm;
 
-  terraform-minimal = pkgs.terraform_0_12;
-
-  terraform = pkgs.terraform_0_12.withPlugins (p: with p; [
+  terraform = trace "Warning: terraform attribute is deprecated, use terraform_(0_12|0_13|0_14) or toolbox make-terraform(12|13|14)-shell" pkgs.terraform_0_12.withPlugins (p: with p; [
     aws
     concourse
     external
@@ -114,7 +113,7 @@ rec {
     p.vault
   ]);
 
-  terraform_0_13 = pkgs.terraform_0_13;
+  terraform-minimal = trace "Warning: terraform-minimal is deprecated use terraform_0_12" pkgs.terraform_0_12;
 
   cue_0_3 = pkgs.callPackage ./pkgs/cue.nix { source = sources.cue; };
 

--- a/pkgs/toolbox/default.nix
+++ b/pkgs/toolbox/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation {
   pname = "toolbox";
-  version = "1.9.0";
+  version = "2.0.0";
 
   buildInputs = [ makeWrapper ];
   passAsFile = [ "buildCommand" ];

--- a/pkgs/toolbox/toolbox.sh
+++ b/pkgs/toolbox/toolbox.sh
@@ -254,7 +254,7 @@ doctor() {
 list() {
     cat <(echo -e "Package#Available#Installed#Description") \
         <(nix-env -f '<toolbox>' -q -a -P -c --description \
-        | sed 's/^\([^ ]*\)[[:space:]]\+[a-z-]\+\([^ ]\+\)[[:space:]]\+\(. [^ ]\+\)[[:space:]]\+\(.*\)/\1#\2#\3#\4/') \
+        | sed 's/^\([^ ]*\)[[:space:]]\+[a-z0-9-]\+[a-z-]\([^ ]\+\)[[:space:]]\+\(. [^ ]\+\)[[:space:]]\+\(.*\)/\1#\2#\3#\4/') \
     | column -s '#' -t | grep --color -E '^|>|<'
 }
 

--- a/toolbox.json
+++ b/toolbox.json
@@ -1,5 +1,5 @@
 {
-    "epoch": 1,
-    "commit": "57f8db0c4fae35a03bec84b82a3fed7556fe3f94",
-    "sha256": "0h3fj153c6kamc1mjp3x69fwgchalfgzz2khvavfn0wqw7d3mvlc"
+  "epoch": 1,
+  "commit": "a6e002f58b4859980c51926b1270895e5a570bd9",
+  "sha256": "155yn9n5rzyl5cxdxls9yy7g50rl2jmywr99ahydbh8skxc1km69"
 }


### PR DESCRIPTION
    * add deprecation messages for `terraform`, `terraform-minimal`
    * expose `terraform_0_12`, `terraform_0_13`, `terraform_0_14` attributes
    * replace `make-terraform-shell` by `make-terraform12-shell`
    * added `make-terraform14-shell` subcommand
    * automatically generate a `terraform.tf` file with providers and source addresses
