### PR TITLE
keycloak: upgrade to v2.3.0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -299,12 +299,12 @@
         "homepage": "https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs",
         "owner": "mrparkers",
         "repo": "terraform-provider-keycloak",
-        "rev": "aaf94d46b648ff954983ea4a55021459ecb00d7a",
-        "sha256": "0calx5g341dcma2fm29alifs0ymvh8bw774d8386gy24vwhnafrk",
+        "rev": "8107493195d5364f010e320faff2cc708a5dcb9d",
+        "sha256": "1msxxbrcwh83czsrydq4bk4p38zrx9s1hrjryh3xf1l55lb6plr1",
         "type": "tarball",
-        "url": "https://github.com/mrparkers/terraform-provider-keycloak/archive/v2.1.0.tar.gz",
+        "url": "https://github.com/mrparkers/terraform-provider-keycloak/archive/v2.3.0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/v<version>.tar.gz",
-        "version": "2.1.0"
+        "version": "2.3.0"
     },
     "terraform-provider-kubernetes-yaml": {
         "branch": "master",

--- a/pkgs/terraform-provider-keycloak.nix
+++ b/pkgs/terraform-provider-keycloak.nix
@@ -17,13 +17,6 @@ buildGoModule rec {
   # Skip the go tests ; they require a running keycloak instance
   doCheck = false;
 
-  patches = [
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/mrparkers/terraform-provider-keycloak/pull/426.patch";
-      sha256 = "11z2dh8wmzy46mjl3vfsdcpvdp1qdkrmv25fmi5vh6agm6ds048f";
-    })
-  ];
-
   meta = with stdenv.lib; {
     description = "Terraform provider for keycloak";
     homepage = "https://github.com/mrparkers/terraform-provider-keycloak";


### PR DESCRIPTION
Upgrading keycloak terraform provider to v2.3.0 : https://github.com/mrparkers/terraform-provider-keycloak/blob/8107493195d5364f010e320faff2cc708a5dcb9d/CHANGELOG.md

We don't need the patch for the `keycloak_saml_client` datasource as it has been included in the version 2.2.0 of the provider : https://github.com/mrparkers/terraform-provider-keycloak/pull/468