### PR TITLE
terraform-provider-vault: 2.16.0 -> 2.19.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -49,6 +49,7 @@ let
           with sources.terraform-provider-vault; {
             inherit version;
             pname = repo;
+            goPackagePath = "github.com/hashicorp/${repo}";
             src = pkgs.fetchzip {
               inherit url sha256;
             };

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -325,12 +325,12 @@
         "homepage": "https://www.terraform.io/docs/providers/vault/",
         "owner": "terraform-providers",
         "repo": "terraform-provider-vault",
-        "rev": "7a173549d849b45abcfd15aad9866b9e6da33e84",
-        "sha256": "14h6ymkc1bksayhzh64y9y2zlcsm5by49kiikn52kz5rkl8cl1dc",
+        "rev": "93cac347e234e52b7edf008deaa752e2043735c9",
+        "sha256": "0b32qx70lyr87531irsyrz62cwxybixqnvl8q75sxvcvfz2fs4ny",
         "type": "tarball",
-        "url": "https://github.com/terraform-providers/terraform-provider-vault/archive/v2.16.0.tar.gz",
+        "url": "https://github.com/terraform-providers/terraform-provider-vault/archive/v2.19.0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/v<version>.tar.gz",
-        "version": "2.16.0"
+        "version": "2.19.0"
     },
     "vault-token-helper": {
         "branch": "master",


### PR DESCRIPTION
Bump vault terraform provider from 2.16.0 to 2.19.0