### PR TITLE
fly: Add v7.3.2 support

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,4 +1,17 @@
 {
+    "concourse_7_3_2": {
+        "branch": "master",
+        "description": "Concourse is a container-based continuous thing-doer written in Go.",
+        "homepage": "https://concourse-ci.org",
+        "owner": "concourse",
+        "repo": "concourse",
+        "rev": "5558b97af40e9e367bae196b254bbc64675b463d",
+        "sha256": "0h6znpj5fmgjqpqcbvsv7kw6fi310lam7iw8pbg74a3k86mfygr0",
+        "type": "tarball",
+        "url": "https://github.com/concourse/concourse/archive/v7.3.2.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/v<version>.tar.gz",
+        "version": "7.3.2"
+    },
     "concourse_6_4_1": {
         "branch": "master",
         "description": "Concourse is a container-based continuous thing-doer written in Go and Elm.",

--- a/pkgs/fly.nix
+++ b/pkgs/fly.nix
@@ -12,6 +12,11 @@ let
 
   fly-wrapper = import sources.fly-wrapper.outPath { inherit pkgs; };
 
+  fly_7_3_2 = fly_go {
+    source = sources.concourse_7_3_2;
+    goVendorSha256 = "0g1rjs7ss0q5j9hbz5kykrkvl1sg6nxl82jay8mln7y88d3fnjnz";
+  };
+
   fly_6_4_1 = fly_go {
     source = sources.concourse_6_4_1;
     goVendorSha256 = "0nv9q3j9cja8c6d7ac8fzb8zf82zz1z77f8cxvn3vxjki7fhlavm";
@@ -89,6 +94,7 @@ let
     fi
 
     case "$VERSION" in
+      7.3.2) FLY_BIN="${fly_7_3_2}/bin" ;;
           *) FLY_BIN="${fly_6_4_1}/bin" ;;
     esac
 


### PR DESCRIPTION
Since we are going to update Concourse from v6.4.1 to v7.3.2, we also will need to use Fly v7.3.2. Once all of our Concourse are updated, I will remove Fly v6.4.1