### PR TITLE
kswitch: run fixup phase

### DIFF
--- a/pkgs/kswitch/default.nix
+++ b/pkgs/kswitch/default.nix
@@ -13,11 +13,14 @@
 
 stdenv.mkDerivation rec {
   pname = "kswitch";
-  version = "1.8.5";
+  version = "1.8.6";
 
   buildInputs = [ makeWrapper ];
-  passAsFile = [ "buildCommand" ];
-  buildCommand = ''
+
+  dontBuild = true;
+  dontConfigure = true;
+  unpackPhase = ":";
+  installPhase = ''
     mkdir -p $out/bin $out/share/bash-completion/completions
     cp ${./kswitch.sh} $out/bin/kswitch
     chmod +x $out/bin/kswitch


### PR DESCRIPTION
Rework build so that the nix fixup phase is run. This will change
kswitch shebang to the absolute path of bash in the nix store.
This way it uses the correct version of bash.