### PR TITLE
autoupdate: ignore terraform-provider-gitlab

### DIFF
--- a/autoupdate/config.yml
+++ b/autoupdate/config.yml
@@ -4,6 +4,8 @@ blacklist:
   - concourse_6_4_1
   - concourse_7_3_2
   - velero
+  # Ignore until https://github.com/gitlabhq/terraform-provider-gitlab/pull/716 is merged
+  - terraform-provider-gitlab
 # Map of mappings used as aliases when triggering a nix build. Key is se beginning  of the package name, Value is the "-A" argument to "nix-build"
 build_mappings:
   terraform-provider: terraform-providers


### PR DESCRIPTION
To be removed when
https://github.com/gitlabhq/terraform-provider-gitlab/pull/716 is
merged. The PR patch doesn't apply cleanly on the latest 3.9.1 version.